### PR TITLE
Fix build on FreeBSD 13.1

### DIFF
--- a/sys/dev/virtio/9pfs/virtfs_vnops.c
+++ b/sys/dev/virtio/9pfs/virtfs_vnops.c
@@ -1611,7 +1611,7 @@ virtfs_symlink(struct vop_symlink_args *ap)
 	struct vnode **vpp;
 	struct vattr *vap;
 	struct componentname *cnp;
-	char *symtgt;
+	const char *symtgt;
 	struct virtfs_node *dnp;
 	struct virtfs_session *vses;
 	struct mount *mp;

--- a/sys/dev/virtio/9pnet/client.c
+++ b/sys/dev/virtio/9pnet/client.c
@@ -247,12 +247,13 @@ p9_client_check_return(struct p9_client *c, struct p9_req_t *req)
 	 * Note this is still not completely an error, as lookups for files
 	 * not present can hit this and return. Hence it is made a debug print.
 	 */
-	if (error != 0)
+	if (error != 0) {
 	        if (req->rc->id == P9PROTO_RERROR) {
 		        p9_debug(TRANS, "<<< RERROR (%d) %s\n", error, ename);
 	        } else if (req->rc->id == P9PROTO_RLERROR) {
 		        p9_debug(TRANS, "<<< RLERROR (%d)\n", error);
 		}
+	}
 
 	if (req->rc->id == P9PROTO_RERROR) {
 	        free(ename, M_TEMP);
@@ -1134,7 +1135,7 @@ p9_client_renameat(struct p9_fid *oldfid, char *oldname, struct p9_fid *newfid,
 
 /* Request to create symbolic link */
 int
-p9_create_symlink(struct p9_fid *fid, char *name, char *symtgt, gid_t gid)
+p9_create_symlink(struct p9_fid *fid, char *name, const char *symtgt, gid_t gid)
 {
 	int error;
 	struct p9_req_t *req;

--- a/sys/dev/virtio/virtio_fs_client.h
+++ b/sys/dev/virtio/virtio_fs_client.h
@@ -149,7 +149,7 @@ void p9_client_cb(struct p9_client *c, struct p9_req_t *req);
 int p9stat_read(struct p9_client *clnt, char *data, size_t len, struct p9_wstat *st);
 void p9_client_disconnect(struct p9_client *clnt);
 void p9_client_begin_disconnect(struct p9_client *clnt);
-int p9_create_symlink(struct p9_fid *fid, char *name, char *symtgt, gid_t gid);
+int p9_create_symlink(struct p9_fid *fid, char *name, const char *symtgt, gid_t gid);
 int p9_create_hardlink(struct p9_fid *dfid, struct p9_fid *oldfid, char *name);
 int p9_readlink(struct p9_fid *fid, char **target);
 int p9_client_renameat(struct p9_fid *oldfid, char *oldname, struct p9_fid *newfid, char *newname);


### PR DESCRIPTION
This fixes a couple errors I got trying to build the driver. With these changes it loads, and a filesystem mounts and initially seems to work.

I don't think these changes should break anything elsewhere.