### PR TITLE
Fix build on recent FreeBSD 14 + Some questions.

### DIFF
--- a/sys/dev/virtio/9pfs/virtfs_vnops.c
+++ b/sys/dev/virtio/9pfs/virtfs_vnops.c
@@ -285,7 +285,9 @@ virtfs_lookup(struct vop_lookup_args *ap)
 			error = VOP_ACCESS(dvp, VWRITE, cnp->cn_cred,
 			    curthread);
 			if (!error) {
+#if __FreeBSD_version < 1400068
 				cnp->cn_flags |= SAVENAME;
+#endif
 				return (EJUSTRETURN);
 			}
 		}
@@ -304,8 +306,10 @@ virtfs_lookup(struct vop_lookup_args *ap)
 		/* Check if the entry in cache is stale or not */
 		if ((virtfs_node_cmp(vp, &newfid->qid) == 0) &&
 		    ((error = VOP_GETATTR(vp, &vattr, cnp->cn_cred)) == 0)) {
+#if __FreeBSD_version < 1400068
 			if (cnp->cn_nameiop != LOOKUP && (flags & ISLASTCN))
 				cnp->cn_flags |= SAVENAME;
+#endif
 			goto out;
 		}
 		/*
@@ -439,8 +443,10 @@ virtfs_lookup(struct vop_lookup_args *ap)
 
 	cnp->cn_nameptr[cnp->cn_namelen] = tmpchr;
 
+#if __FreeBSD_version < 1400068
 	if (cnp->cn_nameiop != LOOKUP && (flags & ISLASTCN))
 		cnp->cn_flags |= SAVENAME;
+#endif
 
 	/* Store the result the cache if MAKEENTRY is specified in flags */
 	if ((cnp->cn_flags & MAKEENTRY) != 0)

--- a/sys/dev/virtio/9pnet/trans_virtio.c
+++ b/sys/dev/virtio/9pnet/trans_virtio.c
@@ -502,7 +502,12 @@ vt9p_modevent(module_t mod, int type, void *unused)
 	return (error);
 }
 
+#if __FreeBSD_version >= 1400058
+DRIVER_MODULE(vt9p, virtio_pci, vt9p_drv,
+    vt9p_modevent, 0);
+#else
 DRIVER_MODULE(vt9p, virtio_pci, vt9p_drv, vt9p_class,
     vt9p_modevent, 0);
+#endif
 MODULE_VERSION(vt9p, 1);
 MODULE_DEPEND(vt9p, virtio, 1, 1, 1);


### PR DESCRIPTION
Hi,

I've started using this software (through the port at [emulators/virtfs-9p-kmod](https://github.com/swills/random-ports/tree/master/emulators/virtfs-9p-kmod)) and find it very useful. Thanks for creating this and the port.

I've noticed it fails to build on recent head due to changes in base, so I created some simple patches that I'm proposing here.

It is working fine for me in a 13.1-RELEASE-p7 VM in bhyve. I plan to actually testing running it on 14 in a VM at some point.

Question 1: Only problem I have found is that it locks up if I access the mounted filesystem through a symlink. I'm simply avoiding symlinking this FS for now.

Question 2: Is there a reason why the port at [emulators/virtfs-9p-kmod](https://github.com/swills/random-ports/tree/master/emulators/virtfs-9p-kmod) has not been committed to the official ports tree? I think it would be a very useful addition.

Thanks again for creating this repo and the port!